### PR TITLE
Set require_ek to false and ca provider to openssl

### DIFF
--- a/roles/ansible-keylime-tpm12/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm12/tasks/keylime.yml
@@ -9,3 +9,15 @@
     dest: /etc
     mode: 0644
     remote_src: yes
+
+- name: Change require_ek_cert to false.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^require_ek_cert'
+    line: require_ek_cert = False
+
+- name: Change ca_implementation to openssl.
+  lineinfile:
+    path: /etc/keylime.conf
+    regexp: '^ca_implementation'
+    line: ca_implementation = openssl

--- a/roles/ansible-keylime-tpm20/tasks/keylime.yml
+++ b/roles/ansible-keylime-tpm20/tasks/keylime.yml
@@ -13,11 +13,11 @@
 - name: Change require_ek_cert to false.
   lineinfile:
     path: /etc/keylime.conf
-    regexp: '^require_ek_cert='
+    regexp: '^require_ek_cert'
     line: require_ek_cert = False
 
 - name: Change ca_implementation to openssl.
   lineinfile:
     path: /etc/keylime.conf
-    regexp: '^ca_implementation='
+    regexp: '^ca_implementation'
     line: ca_implementation = openssl


### PR DESCRIPTION
Require EK should be false (as its a software TPM)

Also set ca provider as openssl, which works without golang
configuration (which we can add later)