### PR TITLE
Multi VM setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,12 +1,47 @@
 Vagrant.configure("2") do |config|
-   config.vm.box = "fedora/30-cloud-base"
-   config.vm.network "forwarded_port", guest: 443, host: 8443
-   config.vm.provider "libvirt" do |vb|
-     vb.random :model => 'random'
-     vb.memory = "2048"
-     vb.cpus = "2"
-   end
-   config.vm.provision "ansible_local" do |ansible|
-       ansible.playbook = "playbook.yml"
+   
+   config.vm.define "keylime1" do |keylime1|
+     keylime1.vm.box = "fedora/30-cloud-base"
+     
+     keylime1.vm.network :private_network, ip: "10.0.0.10"
+     keylime1.vm.hostname= "keylime1"
+     keylime1.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_vagrant/keylime1", "/root/keylime-dev", type: "sshfs"
+     keylime1.vm.network "forwarded_port", guest: 443, host: 8445
+     keylime1.vm.provider "libvirt" do |vb|
+     keylime1.vm.synced_folder ".", "/vagrant"
+       vb.random :model => 'random'
+       vb.memory = "2048"
+       vb.cpus = "2"
+     end
+     keylime1.vm.provision "ansible_local" do |ansible|
+         ansible.playbook = "playbook.yml"
+         ansible.extra_vars = {
+           ansible_python_interpreter:"/usr/bin/python3",
+         }
+         
+    end
+  end
+   config.vm.define "keylime2" do |keylime2|
+     keylime2.vm.box = "fedora/30-cloud-base"
+     
+     keylime2.vm.network :private_network, ip: "10.0.0.11"
+     keylime2.vm.hostname= "keylime2"
+     keylime2.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_vagrant/keylime2", "/root/keylime-dev", type: "sshfs"
+     keylime2.vm.network "forwarded_port", guest: 442, host: 8443
+     keylime2.vm.provider "libvirt" do |vb|
+     keylime2.vm.synced_folder ".", "/vagrant"
+       vb.random :model => 'random'
+       vb.memory = "2048"
+       vb.cpus = "2"
+     end
+     keylime2.vm.provision "ansible_local" do |ansible|
+         ansible.playbook = "playbook.yml"
+         ansible.extra_vars = {
+           ansible_python_interpreter:"/usr/bin/python3",
+         }
+         
+    end
+     
   end
 end
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,29 +1,66 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'getoptlong'
+
+opts = GetoptLong.new(
+  [ '--instances', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--repo', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--cpus', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--memory', GetoptLong::OPTIONAL_ARGUMENT ]
+)
+
+# defaults
+
+instances = 1
+cpus = 2
+memory = 2048
+
+
+opts.ordering=(GetoptLong::REQUIRE_ORDER)
+
+opts.each do |opt, arg|
+  case opt
+    when '--instances'
+      instances = arg.to_i
+    when '--repo'
+      repo = arg
+    when '--cpus'
+      cpus = arg.to_i
+    when '--memory'
+      memory = arg.to_i
+  end
+end
+
 Vagrant.configure("2") do |config|
-   
-   (1..2).each do |i|
+   (1..instances).each do |i|
       config.vm.define "keylime#{i}" do |keylime|
-         keylime.vm.box = "fedora/30-cloud-base"
+         keylime.vm.box = "fedora/31-cloud-base"
          keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
-         keylime.vm.hostname= "keylime#{i}"
-         keylime.vm.synced_folder "<user>/keylime", "/root/keylime-dev", type: "sshfs"
+         if instances == 1
+           hostname = "keylime"
+         else
+           hostname = "keylime#{i}"
+         end
+         keylime.vm.hostname = "#{hostname}"
+         if defined? (repo)
+           keylime.vm.synced_folder "#{repo}", "/root/keylime-dev", type: "sshfs"
+         end
          keylime.vm.provider "virtualbox" do |v|
-          v.memory = "2048"
-          v.cpus = "2"
+          v.memory = "#{memory}"
+          v.cpus = "#{cpus}"
          end
          keylime.vm.provider "libvirt" do |vb|
            vb.random :model => 'random'
-           vb.memory = "4096"
-           vb.cpus = "4"
+           vb.memory = "#{memory}"
+           vb.cpus = "#{cpus}"
          end
          keylime.vm.provision "ansible_local" do |ansible|
              ansible.playbook = "playbook.yml"
              ansible.extra_vars = {
                ansible_python_interpreter:"/usr/bin/python3",
              }
-             
+           end
         end
-      end
     end
-  
 end
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,12 +5,12 @@ Vagrant.configure("2") do |config|
          keylime.vm.box = "fedora/30-cloud-base"
          keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
          keylime.vm.hostname= "keylime#{i}"
-         keylime.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime1", "/root/keylime-dev", type: "sshfs"
+         keylime.vm.synced_folder "<user>/keylime", "/root/keylime-dev", type: "sshfs"
          keylime.vm.provider "virtualbox" do |v|
           v.memory = "2048"
           v.cpus = "2"
          end
-         config.vm.provider "libvirt" do |vb|
+         keylime.vm.provider "libvirt" do |vb|
            vb.random :model => 'random'
            vb.memory = "4096"
            vb.cpus = "4"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,13 +5,12 @@ Vagrant.configure("2") do |config|
      
      keylime1.vm.network :private_network, ip: "10.0.0.10"
      keylime1.vm.hostname= "keylime1"
-     keylime1.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_vagrant/keylime1", "/root/keylime-dev", type: "sshfs"
+     keylime1.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime1", "/root/keylime-dev", type: "sshfs"
      keylime1.vm.network "forwarded_port", guest: 443, host: 8445
-     keylime1.vm.provider "libvirt" do |vb|
-     keylime1.vm.synced_folder ".", "/vagrant"
-       vb.random :model => 'random'
-       vb.memory = "2048"
-       vb.cpus = "2"
+     keylime1.vm.provider "virtualbox" do |v|
+     #keylime1.vm.synced_folder ".", "/vagrant"
+      v.memory = "2048"
+      v.cpus = "2"
      end
      keylime1.vm.provision "ansible_local" do |ansible|
          ansible.playbook = "playbook.yml"
@@ -26,13 +25,12 @@ Vagrant.configure("2") do |config|
      
      keylime2.vm.network :private_network, ip: "10.0.0.11"
      keylime2.vm.hostname= "keylime2"
-     keylime2.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_vagrant/keylime2", "/root/keylime-dev", type: "sshfs"
+     keylime2.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime2", "/root/keylime-dev", type: "sshfs"
      keylime2.vm.network "forwarded_port", guest: 442, host: 8443
-     keylime2.vm.provider "libvirt" do |vb|
-     keylime2.vm.synced_folder ".", "/vagrant"
-       vb.random :model => 'random'
-       vb.memory = "2048"
-       vb.cpus = "2"
+     keylime2.vm.provider "virtualbox" do |v|
+     #keylime2.vm.synced_folder ".", "/vagrant"
+       v.memory = "2048"
+       v.cpus = "2"
      end
      keylime2.vm.provision "ansible_local" do |ansible|
          ansible.playbook = "playbook.yml"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,45 +1,29 @@
 Vagrant.configure("2") do |config|
    
-   config.vm.define "keylime1" do |keylime1|
-     keylime1.vm.box = "fedora/30-cloud-base"
-     
-     keylime1.vm.network :private_network, ip: "10.0.0.10"
-     keylime1.vm.hostname= "keylime1"
-     keylime1.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime1", "/root/keylime-dev", type: "sshfs"
-     keylime1.vm.network "forwarded_port", guest: 443, host: 8445
-     keylime1.vm.provider "virtualbox" do |v|
-     #keylime1.vm.synced_folder ".", "/vagrant"
-      v.memory = "2048"
-      v.cpus = "2"
-     end
-     keylime1.vm.provision "ansible_local" do |ansible|
-         ansible.playbook = "playbook.yml"
-         ansible.extra_vars = {
-           ansible_python_interpreter:"/usr/bin/python3",
-         }
-         
+   (1..2).each do |i|
+      config.vm.define "keylime#{i}" do |keylime|
+         keylime.vm.box = "fedora/30-cloud-base"
+         keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
+         keylime.vm.hostname= "keylime#{i}"
+         keylime.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime1", "/root/keylime-dev", type: "sshfs"
+         keylime.vm.provider "virtualbox" do |v|
+          v.memory = "2048"
+          v.cpus = "2"
+         end
+         config.vm.provider "libvirt" do |vb|
+           vb.random :model => 'random'
+           vb.memory = "4096"
+           vb.cpus = "4"
+         end
+         keylime.vm.provision "ansible_local" do |ansible|
+             ansible.playbook = "playbook.yml"
+             ansible.extra_vars = {
+               ansible_python_interpreter:"/usr/bin/python3",
+             }
+             
+        end
+      end
     end
-  end
-   config.vm.define "keylime2" do |keylime2|
-     keylime2.vm.box = "fedora/30-cloud-base"
-     
-     keylime2.vm.network :private_network, ip: "10.0.0.11"
-     keylime2.vm.hostname= "keylime2"
-     keylime2.vm.synced_folder "/Users/andrewstoycos/Documents/classes_Fall2019/EC528/keylime_multiVM/keylime2", "/root/keylime-dev", type: "sshfs"
-     keylime2.vm.network "forwarded_port", guest: 442, host: 8443
-     keylime2.vm.provider "virtualbox" do |v|
-     #keylime2.vm.synced_folder ".", "/vagrant"
-       v.memory = "2048"
-       v.cpus = "2"
-     end
-     keylime2.vm.provision "ansible_local" do |ansible|
-         ansible.playbook = "playbook.yml"
-         ansible.extra_vars = {
-           ansible_python_interpreter:"/usr/bin/python3",
-         }
-         
-    end
-     
-  end
+  
 end
 

--- a/roles/ansible-keylime-tpm20/tasks/packages.yml
+++ b/roles/ansible-keylime-tpm20/tasks/packages.yml
@@ -103,9 +103,9 @@
       name: python3-requests
       state: latest
 
-- name: Install libselinux-python
+- name: Install libselinux-python3
   dnf:
-    name: libselinux-python
+    name: libselinux-python3
     state: latest
 
 - name: install yaml-cpp-devel


### PR DESCRIPTION
Allow user to spin up a variable number of VMs named keylime1,keylime2...keylimeN. The VMs use ansible to setup and download keylime. They can also use a shared folder to reference the keylime codebase, and provide and easier development loop. It fixes some virtual-box resource allocation errors from the original code, and an issue where ansible attempted to use python2 rather than python3. 

Set the for loop to 1 to have same behavior as original, make sure to fill in your desired shared folder, and make sure to set the --provider flag to either libvert or virtualbox.  A private network is also connected to allow keylime instances to communicate between each other, ip = 10.0.0."KEYLIME#"1  