### PR TITLE
Add details on new args available for Vagrant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ansible Keylime
 ===============
 
-[![Build Status](https://travis-ci.org/keylime/ansible-keylime-soft-tpm.svg?branch=master)](https://travis-ci.org/keylime/ansible-keylime-soft-tpm) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/keylime-project/community)
+[![Build Status](https://travis-ci.org/keylime/ansible-keylime-tpm-emulator.svg?branch=master)](https://travis-ci.org/keylime/ansible-keylime-tpm-emulator) [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/keylime-project/community)
 
 Ansible role to deploy [Keylime](https://github.com/keylime/keylime) and a TPM Emulator,
 alongside the  [Keylime rust cloud node](https://github.com/keylime/rust-keylime)
@@ -56,21 +56,31 @@ Both roles will deploy the relevant TPM 1.2 Emulator (tpm4720) or 2.0 Emulator (
 Vagrant
 -------
 
-If you prefer, a Vagrantfile is available for provisioning.
+A `Vagrantfile` is available for provisioning.
 
-Clone the repository and then simply run `vagrant up --provider <provider> --provision`
+Clone the repository and then simply run with the following additional args
+added to the `vagrant` command:
+
+
+* `--instances`: The number of Keylime Virtual Machines to create. If not provided, it defaults to `1`
+* `--repo`: This mounts your local Keylime git repository into the virtual machine (allowing you to test your code within the VM). This is optional.
+* `--cpus`: The amount of CPU's. If not provided, it defaults to `2`
+* `--memory`: The amount of memory to assign.  If not provided, it defaults to `2048`
 
 For example, using libvirt:
 
 ```
-vagrant up --provider libvirt --provision
+vagrant --instances=2 --repo=/home/jdoe/keylime --cpus=4 --memory=4096  up --provider libvirt --provision
 ```
 
 For example, using VirtualBox:
 
 ```
-vagrant up --provider virtualbox --provision
+vagrant --instances=2 --repo=/home/jdoe/keylime --cpus=4 --memory=4096  up --provider virtualbox --provision
 ```
+
+| NOTE: Customized args (`--instances`, `--repos` etc), come before the mainvagrant args (such as `up`, `--provider`) |
+| --- |
 
 Once the VM is started, vagrant ssh into the VM and run `sudo su -` to
 become root.


### PR DESCRIPTION
New args can now be passed to the vagrant command and allow
injection of options such as the amount of instances, cpu and
memory.

This change outlines the new args within the README.md file