### PR TITLE
roles:tpm20:packages: add required py3-zmq dep

### DIFF
--- a/roles/ansible-keylime-tpm20/tasks/packages.yml
+++ b/roles/ansible-keylime-tpm20/tasks/packages.yml
@@ -137,3 +137,8 @@
   dnf:
       name: tpm2-abrmd
       state: latest
+
+- name: install python3-zmq
+  dnf:
+      name: python3-zmq
+      state: latests


### PR DESCRIPTION
The current impelementation of the keylime_verifier requires zmq. Ensure
that it is installed during provisioning.