### PR TITLE
Comment out ConditionPathExistsGlob

### DIFF
--- a/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
+++ b/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
@@ -49,13 +49,18 @@
     regexp: '^ExecStart='
     line: ExecStart=/usr/sbin/tpm2-abrmd --tcti=mssim
 
+- name: Comment out ConditionPathExistsGlob
+  lineinfile:
+    path: /usr/lib/systemd/system/tpm2-abrmd.service
+    regexp: '^ConditionPathExistsGlob='
+    line: '# ConditionPathExistsGlob=/dev/tpm*'
+
 - name: Reload / restart service tpm2-abrmd, in all cases
   systemd:
     name: tpm2-abrmd
     state: restarted
     daemon_reload: yes
-    
-#
+
 # - name: reload service tpm2-abrmd, in all cases
 #   systemd:
 #     name: tpm2-abrmd


### PR DESCRIPTION
Fedora packaging added the following to the systemd file for
tpm2-abrmd:

`ConditionPathExistsGlob=/dev/tpm*`

This causes the emulator to fail.

This change uses a linereplace to comment out the aforementioned.