### PR TITLE
Updates to Vagrant Ansible role

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,38 +32,38 @@ opts.each do |opt, arg|
 end
 
 Vagrant.configure("2") do |config|
-   (1..instances).each do |i|
-      config.vm.define "keylime#{i}" do |keylime|
-         keylime.vm.box = "fedora/31-cloud-base"
-         # Should you require machines to share a private network
-         # Note, you will need to create the network first within
-         # your provider (VirtualBox / Libvirt etc)
-         # keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
-         keylime.vm.network "forwarded_port", guest: 443, host: "844#{i}"
-         if instances == 1
-           hostname = "keylime"
-         else
-           hostname = "keylime#{i}"
-         end
-         keylime.vm.hostname = "#{hostname}"
-         if defined? (repo)
-           keylime.vm.synced_folder "#{repo}", "/root/keylime-dev", type: "sshfs"
-         end
-         keylime.vm.provider "virtualbox" do |v|
-          v.memory = "#{memory}"
-          v.cpus = "#{cpus}"
-         end
-         keylime.vm.provider "libvirt" do |vb|
-           vb.random :model => 'random'
-           vb.memory = "#{memory}"
-           vb.cpus = "#{cpus}"
-         end
-         keylime.vm.provision "ansible_local" do |ansible|
-             ansible.playbook = "playbook.yml"
-             ansible.extra_vars = {
-               ansible_python_interpreter:"/usr/bin/python3",
-             }
-           end
-        end
+  (1..instances).each do |i|
+    config.vm.define "keylime#{i}" do |keylime|
+      keylime.vm.box = "fedora/31-cloud-base"
+      # Should you require machines to share a private network
+      # Note, you will need to create the network first within
+      # your provider (VirtualBox / Libvirt etc)
+      # keylime.vm.network :private_network, ip: "10.0.0.#{i}1"
+      keylime.vm.network "forwarded_port", guest: 443, host: "844#{i}"
+      if instances == 1
+        hostname = "keylime"
+      else
+        hostname = "keylime#{i}"
+      end
+      keylime.vm.hostname = "#{hostname}"
+      if defined? (repo)
+        keylime.vm.synced_folder "#{repo}", "/root/keylime-dev", type: "sshfs"
+      end
+      keylime.vm.provider "virtualbox" do |v|
+        v.memory = "#{memory}"
+        v.cpus = "#{cpus}"
+      end
+      keylime.vm.provider "libvirt" do |vb|
+        vb.random :model => 'random'
+        vb.memory = "#{memory}"
+        vb.cpus = "#{cpus}"
+      end
+      keylime.vm.provision "ansible_local" do |ansible|
+          ansible.playbook = "playbook.yml"
+          ansible.extra_vars = {
+            ansible_python_interpreter:"/usr/bin/python3",
+          }
+      end
     end
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,8 @@ opts = GetoptLong.new(
   [ '--instances', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--repo', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--cpus', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--memory', GetoptLong::OPTIONAL_ARGUMENT ]
+  [ '--memory', GetoptLong::OPTIONAL_ARGUMENT ],
+  [ '--verbose', GetoptLong::NO_ARGUMENT ]
 )
 
 # defaults
@@ -15,6 +16,7 @@ instances = 1
 cpus = 2
 memory = 2048
 repo = ''
+verbose = ''
 
 opts.ordering=(GetoptLong::REQUIRE_ORDER)
 
@@ -28,6 +30,8 @@ opts.each do |opt, arg|
       cpus = arg.to_i
     when '--memory'
       memory = arg.to_i
+    when '--verbose'
+      verbose = true
   end
 end
 
@@ -63,6 +67,9 @@ Vagrant.configure("2") do |config|
           ansible.extra_vars = {
             ansible_python_interpreter:"/usr/bin/python3",
           }
+          if defined? (verbose) and verbose == true
+            ansible.verbose = true
+          end
       end
     end
   end

--- a/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
+++ b/roles/ansible-keylime-tpm20/tasks/ibm-tpm.yml
@@ -17,10 +17,10 @@
   command: install -c /root/ibmtpm/src/tpm_server /usr/local/bin/tpm_server
 
 - name: Install init_tpm_server script
-  command: install -c /root/keylime/swtpm2_scripts/init_tpm_server /usr/local/bin/init_tpm_server
+  command: install -c /root/keylime/scripts/init_tpm_server /usr/local/bin/init_tpm_server
 
 - name: Install tpm_serverd script
-  command: install -c /root/keylime/swtpm2_scripts/tpm_serverd /usr/local/bin/tpm_serverd
+  command: install -c /root/keylime/scripts/tpm_serverd /usr/local/bin/tpm_serverd
 
 - name: Changing perm of "tpm_serverd", adding "+x"
   file: dest=/usr/local/bin/tpm_serverd mode=a+x


### PR DESCRIPTION
This updates the Vagrant Ansible role to:
- Add a verbose option to Ansible for debugging purposes.
- Update the IBM TPM task to specify the new software TPM `scripts` directory after the directory moved.
- Fix formatting issues in Vagrantfile.