### PR TITLE
Add vagrant config file for setting defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
 roles/fubarhouse.rust
+vagrant_variables.yml

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ vagrant --instances=2 --repo=/home/jdoe/keylime --cpus=4 --memory=4096  up --pro
 | NOTE: Customized args (`--instances`, `--repos` etc), come before the mainvagrant args (such as `up`, `status`, `--provider`). Example: To `ssh` into the second machine instance, keylime2, use the vagrant command as such : `vagrant --instances=2 ssh keylime2` |
 | --- |
 
+If you would like to set these defaults and customize them without having to
+specify them on the command line each time, then use the
+`vagrant_variables.yml.sample` vagrant variables config file and copy it to
+`vagrant_variables.yml`:
+
+```shell
+cp vagrant_variables.yml.sample vagrant_variables.yml
+```
+
+You can still override the defaults in `vagrant_variables.yml` by using the
+command line options.
+
 Once the VM is started, vagrant ssh into the VM and run `sudo su -` to
 become root.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 
 require 'getoptlong'
+require 'yaml'
 
 opts = GetoptLong.new(
   [ '--instances', GetoptLong::OPTIONAL_ARGUMENT ],
@@ -11,15 +12,24 @@ opts = GetoptLong.new(
   [ '--verbose', GetoptLong::NO_ARGUMENT ]
 )
 
-# defaults
-instances = 1
-cpus = 2
-memory = 2048
-repo = ''
-verbose = ''
+config_file = File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
+
+settings={}
+if File.exist?(config_file)
+  settings = YAML.load_file(config_file)
+end
+
+# Use defaults defined in vagrant variables file, otherwise set defaults.
+instances = settings['instances'] ? settings['instances'] : 1
+cpus      = settings['cpus']      ? settings['cpus']      : 2
+memory    = settings['memory']    ? settings['memory']    : 2048
+repo      = settings['repo']      ? settings['repo']      : ''
+verbose   = settings['verbose']   ? settings['verbose']   : false
 
 opts.ordering=(GetoptLong::REQUIRE_ORDER)
 
+# Command line options take precedence i.e. override any defaults if command
+# line options are provided.
 opts.each do |opt, arg|
   case opt
     when '--instances'

--- a/vagrant_variables.yml.sample
+++ b/vagrant_variables.yml.sample
@@ -1,0 +1,17 @@
+# Define defaults to use in the Vagrantfile.
+
+# Number of virtual machine instances.
+instances: 1
+
+# The number of CPUs to use.
+cpus: 2
+
+# The amount of memory to assign.
+memory: 2048
+
+# Location of your local Keylime git repository to sync into the virtual
+# machine. This allows you to test your code within the VM.
+repo: '/path/to/keylime'
+
+# Set verbosity during Ansible provisioning.
+verbose: false


### PR DESCRIPTION
This allows the user to specify defaults in a vagrant variables config file without having to specify options on the command line for each vagrant command. I opted to not commit the actual `vagrant_variables.yml` file so that the user is forced to explicitly set and use the config file to avoid any confusion.