### PR TITLE
Add a  "quality of life" option to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,8 @@ opts = GetoptLong.new(
   [ '--repo', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--cpus', GetoptLong::OPTIONAL_ARGUMENT ],
   [ '--memory', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--verbose', GetoptLong::NO_ARGUMENT ]
+  [ '--verbose', GetoptLong::NO_ARGUMENT ],
+  [ '--qualityoflife', GetoptLong::NO_ARGUMENT ]
 )
 
 config_file = File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
@@ -25,6 +26,7 @@ cpus      = settings['cpus']      ? settings['cpus']      : 2
 memory    = settings['memory']    ? settings['memory']    : 2048
 repo      = settings['repo']      ? settings['repo']      : ''
 verbose   = settings['verbose']   ? settings['verbose']   : false
+qualityoflife   = settings['qualityoflife']   ? settings['qualityoflife']   : false
 
 opts.ordering=(GetoptLong::REQUIRE_ORDER)
 
@@ -42,6 +44,8 @@ opts.each do |opt, arg|
       memory = arg.to_i
     when '--verbose'
       verbose = true
+    when '--qualityoflife'
+      qualityoflife = true
   end
 end
 
@@ -73,6 +77,7 @@ Vagrant.configure("2") do |config|
         vb.cpus = "#{cpus}"
       end
       keylime.vm.provision "ansible_local" do |ansible|
+          ansible.verbose = "v"
           ansible.playbook = "playbook.yml"
           ansible.extra_vars = {
             ansible_python_interpreter:"/usr/bin/python3",
@@ -80,6 +85,15 @@ Vagrant.configure("2") do |config|
           if defined? (verbose) and verbose == true
             ansible.verbose = true
           end
+      end
+      if defined? (qualityoflife) and qualityoflife == true
+        keylime.vm.provision "ansible_local" do |ansible|
+            ansible.verbose = "v"
+            ansible.playbook = "quality_of_life.yml"
+            if defined? (verbose) and verbose == true
+              ansible.verbose = true
+            end
+        end
       end
     end
   end

--- a/extras/.vimrc
+++ b/extras/.vimrc
@@ -1,0 +1,8 @@
+" Enable Powerline for Vim
+python3 from powerline.vim import setup as powerline_setup
+python3 powerline_setup()
+python3 del powerline_setup
+set laststatus=2 " Always display the statusline in all windows
+set showtabline=2 " Always display the tabline, even if there is only one tab
+set noshowmode " Hide the default mode text (e.g. -- INSERT -- below the statusline)
+set t_Co=256

--- a/playbook.yml
+++ b/playbook.yml
@@ -6,9 +6,14 @@
       selinux:
         policy: targeted
         state: permissive
-    - name: 'install python3'
-      raw: sudo dnf -y install python3
-    - name: 'install libselinux-python3'
-      raw: sudo dnf -y install libselinux-python3
+    - name: Ensure Python 3 is available
+      dnf:
+        name: python3
+        state: present
+    - name: Install libselinux-python3
+      dnf:
+        name: libselinux-python3
+        state: present
   roles:
     - ansible-keylime-tpm20
+    - ansible-keylime-user

--- a/quality_of_life.yml
+++ b/quality_of_life.yml
@@ -1,0 +1,35 @@
+---
+- hosts: all
+  become: true
+  tasks:
+    - name: Enable "ll" as an alias for "ls -lAh"
+      lineinfile:
+        path: /home/vagrant/.bashrc
+        line: alias ll='ls -lAh'
+        insertafter: "User specific aliases and functions"
+    - name: Install Powerline, an improved shell prompt
+      dnf:
+        name: powerline
+        state: present
+    - name: Set up Powerline
+      blockinfile:
+        path: /home/vagrant/.bashrc
+        block: |
+          ## Enable Poweline, an improved shell prompt
+          if [ -f `which powerline-daemon` ]; then
+            powerline-daemon -q
+            POWERLINE_BASH_CONTINUATION=1
+            POWERLINE_BASH_SELECT=1
+            . /usr/share/powerline/bash/powerline.sh
+          fi
+    - name: Install vim-powerline
+      dnf:
+        name: vim-powerline
+        state: present
+    - name: Install .vimrc file
+      copy:
+        src: extras/.vimrc
+        dest: /home/vagrant/.vimrc
+        mode: 0644
+        owner: vagrant
+        group: vagrant


### PR DESCRIPTION
This patch adds a `--qualityoflife` option to the Vagrantfile, which will make life a bit easier in the VMs started by Vagrant by giving you a few nice-to-haves, such as Powerline for an improved command line prompt and 'll' as an alias to 'ls -lAh's.

Opinions and reviews welcome!