### PR TITLE
Remove "ansible-keylime-user" role

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -16,4 +16,3 @@
         state: present
   roles:
     - ansible-keylime-tpm20
-    - ansible-keylime-user


### PR DESCRIPTION
The role made its way into the file by mistake, as part of testing something else.
Removing it.

Signed-off-by: axelsimon <github@axelsimon.net>